### PR TITLE
feat: add mongodb-memory-server for in-memory testing

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,0 +1,26 @@
+{
+  "testEnvironment": "node",
+  "coverageDirectory": "coverage",
+  "collectCoverageFrom": [
+    "src/**/*.js",
+    "!src/server.js",
+    "!src/app.js",
+    "!src/swagger.js",
+    "!src/test/**",
+    "!src/config/**"
+  ],
+  "testMatch": [
+    "**/src/test/**/*.test.js"
+  ],
+  "setupFilesAfterEnv": ["<rootDir>/src/test/setup.js"],
+  "verbose": true,
+  "testTimeout": 10000,
+  "coverageThreshold": {
+    "global": {
+      "branches": 70,
+      "functions": 70,
+      "lines": 70,
+      "statements": 70
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "joi": "^18.0.1",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.20.0",
+        "mongodb-memory-server": "^10.2.3",
         "mongoose": "^8.19.1",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1"
@@ -1927,6 +1928,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2148,6 +2158,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2179,6 +2198,20 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-jest": {
@@ -2287,6 +2320,20 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.0.tgz",
+      "integrity": "sha512-AOhh6Bg5QmFIXdViHbMc2tLDsBIRxdkIaIddPslJF9Z5De3APBScuqGP2uThXnIpqFrgoxMNC6km7uXNIMLHXA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.7",
@@ -2414,6 +2461,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -2825,6 +2881,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -3910,6 +3972,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4056,6 +4127,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4138,6 +4215,47 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/find-up": {
@@ -4759,6 +4877,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -6787,6 +6918,55 @@
         "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
+    "node_modules/mongodb-memory-server": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.2.3.tgz",
+      "integrity": "sha512-/ZNXX2IwmEXErt3HGgJCxYqmfS3thDG5W3cdoMBsC55U/PPzGoAFcdUruvP88uOETLZBBpLbNaWdk2LlinyRlg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "10.2.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.2.3.tgz",
+      "integrity": "sha512-a6OMGO2xJDvxCxNpRpxmy4roMGXQQRIB/2uZyoCWRdDQBIr4o6KMhRzWV5PTrKPk+BavQ+W46j4S1Dj4PpUGXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.4.1",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.9",
+        "https-proxy-agent": "^7.0.6",
+        "mongodb": "^6.9.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.7.2",
+        "tar-stream": "^3.1.7",
+        "tslib": "^2.8.1",
+        "yauzl": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mongoose": {
       "version": "8.19.1",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.19.1.tgz",
@@ -6879,6 +7059,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
       }
     },
     "node_modules/node-int64": {
@@ -7207,7 +7399,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7265,7 +7456,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7331,6 +7521,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7378,7 +7574,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -7391,7 +7586,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -7405,7 +7599,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -7418,7 +7611,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -7434,7 +7626,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -8351,6 +8542,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -8802,6 +9004,17 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -8837,6 +9050,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-table": {
@@ -8973,9 +9195,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -9655,6 +9875,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "joi": "^18.0.1",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.20.0",
+    "mongodb-memory-server": "^10.2.3",
     "mongoose": "^8.19.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"

--- a/src/app.js
+++ b/src/app.js
@@ -60,9 +60,9 @@ app.use('/api/v1/users', userRoute); // Authentication routes
 app.use('/api/v1/profile', profileRoute); // Profile management routes
 
 // Home route
-app.use('/', (req, res) => {
-  return res.end('Welcome to MealGenie API');
-});
+// app.use('/', (req, res) => {
+//   return res.end('Welcome to MealGenie API');
+// });
 
 // Middleware for catching unexisted routes
 // For more specifically, if there is an unmatched route ascendingly, this middleware will run

--- a/src/service/userService.js
+++ b/src/service/userService.js
@@ -109,7 +109,6 @@ class UserService {
         throw new AppError('User not found', 404);
       }
 
-      console.log(updatedUser);
 
       return updatedUser;
     } catch (error) {

--- a/src/test/helpers/mockData.js
+++ b/src/test/helpers/mockData.js
@@ -1,0 +1,76 @@
+const mongoose = require('mongoose');
+
+// Mock user data
+const mockUserData = {
+  email: 'test@example.com',
+  password: 'Password123',
+  name: 'Test User',
+  age: 25,
+  gender: 'male',
+  height: 175,
+  weight: 70,
+  goal: 'build_muscle',
+  preferences: ['vegetarian', 'high_protein'],
+  allergies: ['nuts'],
+};
+
+const mockUserData2 = {
+  email: 'test2@example.com',
+  password: 'Password456',
+  name: 'Test User 2',
+  age: 30,
+  gender: 'female',
+  height: 165,
+  weight: 60,
+  goal: 'lose_weight',
+  preferences: ['low_carb'],
+  allergies: [],
+};
+
+const invalidUserData = {
+  email: 'invalid-email',
+  password: '123', // Too short
+  name: '',
+  age: 10, // Too young
+  gender: 'invalid',
+  height: 30, // Too short
+  weight: 10, // Too light
+  goal: 'invalid_goal',
+};
+
+const mockUpdateData = {
+  name: 'Updated Name',
+  age: 26,
+  weight: 72,
+  goal: 'maintain_weight',
+  preferences: ['vegan', 'organic'],
+};
+
+const mockPasswordChange = {
+  currentPassword: 'Password123',
+  newPassword: 'NewPassword456',
+};
+
+const mockLoginData = {
+  email: 'test@example.com',
+  password: 'Password123',
+};
+
+const createMockUser = (overrides = {}) => {
+  return { ...mockUserData, ...overrides };
+};
+
+const createMockObjectId = () => {
+  return new mongoose.Types.ObjectId();
+};
+
+module.exports = {
+  mockUserData,
+  mockUserData2,
+  invalidUserData,
+  mockUpdateData,
+  mockPasswordChange,
+  mockLoginData,
+  createMockUser,
+  createMockObjectId,
+};

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,0 +1,32 @@
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+let mongoServer;
+
+// Setup before all tests
+beforeAll(async () => {
+  // Close any existing connections
+  await mongoose.disconnect();
+  
+  // Create in-memory MongoDB instance
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+  
+  await mongoose.connect(mongoUri);
+});
+
+// Cleanup after all tests
+afterAll(async () => {
+  if (mongoServer) {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  }
+});
+
+// Clear all collections after each test
+afterEach(async () => {
+  const collections = mongoose.connection.collections;
+  for (const key in collections) {
+    await collections[key].deleteMany({});
+  }
+});

--- a/src/test/unit/middleware/authMiddleware.test.js
+++ b/src/test/unit/middleware/authMiddleware.test.js
@@ -1,0 +1,322 @@
+const jwt = require('jsonwebtoken');
+const {
+  generateToken,
+  authenticate,
+  restrictTo,
+  createSendToken,
+} = require('../../../middleware/authMiddleware');
+const User = require('../../../model/userModel');
+const AppError = require('../../../util/AppError');
+const { mockUserData, createMockObjectId } = require('../../helpers/mockData');
+
+// Mock dependencies
+jest.mock('jsonwebtoken');
+jest.mock('../../../model/userModel');
+
+describe('Auth Middleware Tests', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      JWT_SECRET: 'test-secret-key',
+      JWT_EXPIRES_IN: '7d',
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('generateToken', () => {
+    it('should generate a valid JWT token', () => {
+      const userId = createMockObjectId();
+      const mockToken = 'mock.jwt.token';
+
+      jwt.sign.mockReturnValue(mockToken);
+
+      const token = generateToken(userId);
+
+      expect(jwt.sign).toHaveBeenCalledWith(
+        { id: userId },
+        'test-secret-key',
+        { expiresIn: '7d' }
+      );
+      expect(token).toBe(mockToken);
+    });
+
+    it('should use default expiration if JWT_EXPIRES_IN not set', () => {
+      delete process.env.JWT_EXPIRES_IN;
+      const userId = createMockObjectId();
+      const mockToken = 'mock.jwt.token';
+
+      jwt.sign.mockReturnValue(mockToken);
+
+      generateToken(userId);
+
+      expect(jwt.sign).toHaveBeenCalledWith(
+        { id: userId },
+        'test-secret-key',
+        { expiresIn: '7d' }
+      );
+    });
+  });
+
+  describe('authenticate', () => {
+    let req, res, next;
+
+    beforeEach(() => {
+      req = {
+        headers: {},
+      };
+      res = {};
+      next = jest.fn();
+    });
+
+    it('should authenticate user with valid token', async () => {
+      const userId = createMockObjectId();
+      const mockToken = 'valid.jwt.token';
+      const mockUser = {
+        _id: userId,
+        ...mockUserData,
+        isActive: true,
+      };
+
+      req.headers.authorization = `Bearer ${mockToken}`;
+      jwt.verify.mockReturnValue({ id: userId });
+      User.findById.mockResolvedValue(mockUser);
+
+      await authenticate(req, res, next);
+
+      expect(jwt.verify).toHaveBeenCalledWith(mockToken, 'test-secret-key');
+      expect(User.findById).toHaveBeenCalledWith(userId);
+      expect(req.user).toEqual(mockUser);
+      expect(next).toHaveBeenCalledWith();
+    });
+
+    it('should fail if no token provided', async () => {
+      await authenticate(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'You are not logged in! Please log in to get access.',
+          statusCode: 401,
+        })
+      );
+    });
+
+    it('should fail with invalid token format', async () => {
+      req.headers.authorization = 'InvalidToken';
+
+      await authenticate(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 401,
+        })
+      );
+    });
+
+    it('should fail with invalid JWT token', async () => {
+      const mockToken = 'invalid.jwt.token';
+      req.headers.authorization = `Bearer ${mockToken}`;
+
+      jwt.verify.mockImplementation(() => {
+        const error = new Error('Invalid token');
+        error.name = 'JsonWebTokenError';
+        throw error;
+      });
+
+      await authenticate(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Invalid token. Please log in again!',
+          statusCode: 401,
+        })
+      );
+    });
+
+    it('should fail with expired token', async () => {
+      const mockToken = 'expired.jwt.token';
+      req.headers.authorization = `Bearer ${mockToken}`;
+
+      jwt.verify.mockImplementation(() => {
+        const error = new Error('Token expired');
+        error.name = 'TokenExpiredError';
+        throw error;
+      });
+
+      await authenticate(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Your token has expired! Please log in again.',
+          statusCode: 401,
+        })
+      );
+    });
+
+    it('should fail if user no longer exists', async () => {
+      const userId = createMockObjectId();
+      const mockToken = 'valid.jwt.token';
+
+      req.headers.authorization = `Bearer ${mockToken}`;
+      jwt.verify.mockReturnValue({ id: userId });
+      User.findById.mockResolvedValue(null);
+
+      await authenticate(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'The user belonging to this token does no longer exist.',
+          statusCode: 401,
+        })
+      );
+    });
+
+    it('should fail if user is inactive', async () => {
+      const userId = createMockObjectId();
+      const mockToken = 'valid.jwt.token';
+      const mockUser = {
+        _id: userId,
+        ...mockUserData,
+        isActive: false,
+      };
+
+      req.headers.authorization = `Bearer ${mockToken}`;
+      jwt.verify.mockReturnValue({ id: userId });
+      User.findById.mockResolvedValue(mockUser);
+
+      await authenticate(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message:
+            'Your account has been deactivated. Please contact support.',
+          statusCode: 401,
+        })
+      );
+    });
+
+    it('should handle other JWT errors', async () => {
+      const mockToken = 'error.jwt.token';
+      req.headers.authorization = `Bearer ${mockToken}`;
+
+      jwt.verify.mockImplementation(() => {
+        throw new Error('Some other error');
+      });
+
+      await authenticate(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Authentication failed',
+          statusCode: 401,
+        })
+      );
+    });
+  });
+
+  describe('restrictTo', () => {
+    let req, res, next;
+
+    beforeEach(() => {
+      req = {
+        user: { role: 'user' },
+      };
+      res = {};
+      next = jest.fn();
+    });
+
+    it('should allow access for authorized role', () => {
+      const middleware = restrictTo('user', 'admin');
+
+      middleware(req, res, next);
+
+      expect(next).toHaveBeenCalledWith();
+    });
+
+    it('should deny access for unauthorized role', () => {
+      req.user.role = 'user';
+      const middleware = restrictTo('admin');
+
+      middleware(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'You do not have permission to perform this action',
+          statusCode: 403,
+        })
+      );
+    });
+
+    it('should allow access for multiple roles', () => {
+      req.user.role = 'moderator';
+      const middleware = restrictTo('user', 'moderator', 'admin');
+
+      middleware(req, res, next);
+
+      expect(next).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('createSendToken', () => {
+    let res;
+
+    beforeEach(() => {
+      res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+        ok: jest.fn().mockReturnThis(),
+      };
+      jwt.sign.mockReturnValue('mock.jwt.token');
+    });
+
+    it('should create and send token with user data', () => {
+      const mockUser = {
+        _id: createMockObjectId(),
+        ...mockUserData,
+        password: 'hashedpassword',
+      };
+
+      createSendToken(mockUser, 200, res, 'Login successful');
+
+      expect(jwt.sign).toHaveBeenCalled();
+      expect(mockUser.password).toBeUndefined();
+      expect(res.ok).toHaveBeenCalledWith(
+        { token: 'mock.jwt.token', user: mockUser },
+        'Login successful',
+        200
+      );
+    });
+
+    it('should use default message if not provided', () => {
+      const mockUser = {
+        _id: createMockObjectId(),
+        email: 'test@example.com',
+      };
+
+      createSendToken(mockUser, 200, res);
+
+      expect(res.ok).toHaveBeenCalledWith(
+        { token: 'mock.jwt.token', user: mockUser },
+        'Success',
+        200
+      );
+    });
+
+    it('should remove password from user object', () => {
+      const mockUser = {
+        _id: createMockObjectId(),
+        email: 'test@example.com',
+        password: 'shouldBeRemoved',
+      };
+
+      createSendToken(mockUser, 201, res, 'User created');
+
+      expect(mockUser.password).toBeUndefined();
+    });
+  });
+});

--- a/src/test/unit/middleware/validator.test.js
+++ b/src/test/unit/middleware/validator.test.js
@@ -1,0 +1,112 @@
+const { handleValidationErrors } = require('../../../middleware/validator');
+const { validationResult } = require('express-validator');
+const AppError = require('../../../util/AppError');
+
+// Mock express-validator
+jest.mock('express-validator', () => ({
+  validationResult: jest.fn(),
+}));
+
+describe('Validator Middleware Tests', () => {
+  let req, res, next;
+
+  beforeEach(() => {
+    req = {};
+    res = {};
+    next = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  describe('handleValidationErrors', () => {
+    it('should call next() if no validation errors', () => {
+      validationResult.mockReturnValue({
+        isEmpty: () => true,
+        array: () => [],
+      });
+
+      handleValidationErrors(req, res, next);
+
+      expect(next).toHaveBeenCalledWith();
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call next with AppError if validation errors exist', () => {
+      const mockErrors = [
+        { msg: 'Email is required' },
+        { msg: 'Password must be at least 6 characters' },
+      ];
+
+      validationResult.mockReturnValue({
+        isEmpty: () => false,
+        array: () => mockErrors,
+      });
+
+      handleValidationErrors(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message:
+            'Validation Error: Email is required, Password must be at least 6 characters',
+          statusCode: 400,
+        })
+      );
+    });
+
+    it('should handle single validation error', () => {
+      const mockErrors = [{ msg: 'Invalid email format' }];
+
+      validationResult.mockReturnValue({
+        isEmpty: () => false,
+        array: () => mockErrors,
+      });
+
+      handleValidationErrors(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Validation Error: Invalid email format',
+          statusCode: 400,
+        })
+      );
+    });
+
+    it('should combine multiple error messages', () => {
+      const mockErrors = [
+        { msg: 'Name is required' },
+        { msg: 'Age must be at least 13' },
+        { msg: 'Height is required' },
+      ];
+
+      validationResult.mockReturnValue({
+        isEmpty: () => false,
+        array: () => mockErrors,
+      });
+
+      handleValidationErrors(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message:
+            'Validation Error: Name is required, Age must be at least 13, Height is required',
+          statusCode: 400,
+        })
+      );
+    });
+
+    it('should create AppError instance', () => {
+      const mockErrors = [{ msg: 'Test error' }];
+
+      validationResult.mockReturnValue({
+        isEmpty: () => false,
+        array: () => mockErrors,
+      });
+
+      handleValidationErrors(req, res, next);
+
+      const calledWith = next.mock.calls[0][0];
+      expect(calledWith).toBeInstanceOf(AppError);
+      expect(calledWith.statusCode).toBe(400);
+      expect(calledWith.isOperational).toBe(true);
+    });
+  });
+});

--- a/src/test/unit/model/userModel.test.js
+++ b/src/test/unit/model/userModel.test.js
@@ -1,0 +1,357 @@
+const User = require('../../../model/userModel');
+const { mockUserData, createMockUser } = require('../../helpers/mockData');
+require('../../setup');
+
+describe('User Model Tests', () => {
+  describe('User Creation', () => {
+    it('should create a new user with valid data', async () => {
+      const user = new User(mockUserData);
+      const savedUser = await user.save();
+
+      expect(savedUser._id).toBeDefined();
+      expect(savedUser.email).toBe(mockUserData.email.toLowerCase());
+      expect(savedUser.name).toBe(mockUserData.name);
+      expect(savedUser.age).toBe(mockUserData.age);
+      expect(savedUser.gender).toBe(mockUserData.gender);
+      expect(savedUser.height).toBe(mockUserData.height);
+      expect(savedUser.weight).toBe(mockUserData.weight);
+      expect(savedUser.goal).toBe(mockUserData.goal);
+      expect(savedUser.preferences).toEqual(mockUserData.preferences);
+      expect(savedUser.allergies).toEqual(mockUserData.allergies);
+      expect(savedUser.isActive).toBe(true);
+      expect(savedUser.password).not.toBe(mockUserData.password); // Should be hashed
+    });
+
+    it('should hash password before saving', async () => {
+      const user = new User(mockUserData);
+      await user.save();
+
+      expect(user.password).not.toBe(mockUserData.password);
+      expect(user.password).toMatch(/^\$2[ayb]\$.{56}$/); // bcrypt format
+    });
+
+    it('should convert email to lowercase', async () => {
+      const user = new User({
+        ...mockUserData,
+        email: 'TEST@EXAMPLE.COM',
+      });
+      const savedUser = await user.save();
+
+      expect(savedUser.email).toBe('test@example.com');
+    });
+
+    it('should trim whitespace from fields', async () => {
+      const user = new User({
+        ...mockUserData,
+        name: '  Test User  ',
+        email: '  test@example.com  ',
+      });
+      const savedUser = await user.save();
+
+      expect(savedUser.name).toBe('Test User');
+      expect(savedUser.email).toBe('test@example.com');
+    });
+
+    it('should set default values', async () => {
+      const user = new User(mockUserData);
+      const savedUser = await user.save();
+
+      expect(savedUser.isActive).toBe(true);
+      expect(savedUser.createdAt).toBeDefined();
+      expect(savedUser.updatedAt).toBeDefined();
+    });
+  });
+
+  describe('User Validation', () => {
+    it('should fail without required email', async () => {
+      const user = new User({ ...mockUserData, email: undefined });
+
+      await expect(user.save()).rejects.toThrow(/email/i);
+    });
+
+    it('should fail without required password', async () => {
+      const user = new User({ ...mockUserData, password: undefined });
+
+      await expect(user.save()).rejects.toThrow(/password/i);
+    });
+
+    it('should fail without required name', async () => {
+      const user = new User({ ...mockUserData, name: undefined });
+
+      await expect(user.save()).rejects.toThrow(/name/i);
+    });
+
+    it('should fail with invalid email format', async () => {
+      const user = new User({ ...mockUserData, email: 'invalid-email' });
+
+      await expect(user.save()).rejects.toThrow(/valid email/i);
+    });
+
+    it('should fail with password less than 6 characters', async () => {
+      const user = new User({ ...mockUserData, password: '12345' });
+
+      await expect(user.save()).rejects.toThrow(/at least 6 characters/i);
+    });
+
+    it('should fail with name exceeding 50 characters', async () => {
+      const longName = 'a'.repeat(51);
+      const user = new User({ ...mockUserData, name: longName });
+
+      await expect(user.save()).rejects.toThrow(/cannot exceed 50 characters/i);
+    });
+
+    it('should fail with age less than 13', async () => {
+      const user = new User({ ...mockUserData, age: 12 });
+
+      await expect(user.save()).rejects.toThrow(/at least 13/i);
+    });
+
+    it('should fail with age greater than 120', async () => {
+      const user = new User({ ...mockUserData, age: 121 });
+
+      await expect(user.save()).rejects.toThrow(/cannot exceed 120/i);
+    });
+
+    it('should fail with invalid gender', async () => {
+      const user = new User({ ...mockUserData, gender: 'invalid' });
+
+      await expect(user.save()).rejects.toThrow(/gender/i);
+    });
+
+    it('should fail with height less than 50', async () => {
+      const user = new User({ ...mockUserData, height: 49 });
+
+      await expect(user.save()).rejects.toThrow(/at least 50/i);
+    });
+
+    it('should fail with height greater than 300', async () => {
+      const user = new User({ ...mockUserData, height: 301 });
+
+      await expect(user.save()).rejects.toThrow(/cannot exceed 300/i);
+    });
+
+    it('should fail with weight less than 20', async () => {
+      const user = new User({ ...mockUserData, weight: 19 });
+
+      await expect(user.save()).rejects.toThrow(/at least 20/i);
+    });
+
+    it('should fail with weight greater than 500', async () => {
+      const user = new User({ ...mockUserData, weight: 501 });
+
+      await expect(user.save()).rejects.toThrow(/cannot exceed 500/i);
+    });
+
+    it('should fail with invalid goal', async () => {
+      const user = new User({ ...mockUserData, goal: 'invalid_goal' });
+
+      await expect(user.save()).rejects.toThrow(/goal/i);
+    });
+
+    it('should succeed with all valid goals', async () => {
+      const validGoals = [
+        'lose_weight',
+        'maintain_weight',
+        'gain_weight',
+        'build_muscle',
+        'improve_health',
+      ];
+
+      for (const goal of validGoals) {
+        const user = new User({
+          ...mockUserData,
+          email: `test-${goal}@example.com`,
+          goal,
+        });
+        const savedUser = await user.save();
+        expect(savedUser.goal).toBe(goal);
+      }
+    });
+
+    it('should enforce unique email constraint', async () => {
+      const user1 = new User(mockUserData);
+      await user1.save();
+
+      const user2 = new User(mockUserData);
+      await expect(user2.save()).rejects.toThrow();
+    });
+  });
+
+  describe('User Instance Methods', () => {
+    describe('comparePassword', () => {
+      it('should return true for correct password', async () => {
+        const user = new User(mockUserData);
+        await user.save();
+
+        const isMatch = await user.comparePassword('Password123');
+        expect(isMatch).toBe(true);
+      });
+
+      it('should return false for incorrect password', async () => {
+        const user = new User(mockUserData);
+        await user.save();
+
+        const isMatch = await user.comparePassword('WrongPassword');
+        expect(isMatch).toBe(false);
+      });
+
+      it('should handle empty password', async () => {
+        const user = new User(mockUserData);
+        await user.save();
+
+        const isMatch = await user.comparePassword('');
+        expect(isMatch).toBe(false);
+      });
+    });
+
+    describe('getPublicProfile', () => {
+      it('should return user object without password', async () => {
+        const user = new User(mockUserData);
+        await user.save();
+
+        const publicProfile = user.getPublicProfile();
+
+        expect(publicProfile.password).toBeUndefined();
+        expect(publicProfile.email).toBe(mockUserData.email);
+        expect(publicProfile.name).toBe(mockUserData.name);
+      });
+    });
+  });
+
+  describe('User Schema Hooks', () => {
+    it('should not rehash password if not modified', async () => {
+      const user = new User(mockUserData);
+      await user.save();
+      const firstPassword = user.password;
+
+      user.name = 'Updated Name';
+      await user.save();
+
+      expect(user.password).toBe(firstPassword);
+    });
+
+    it('should rehash password if modified', async () => {
+      const user = new User(mockUserData);
+      await user.save();
+      const firstPassword = user.password;
+
+      user.password = 'NewPassword123';
+      await user.save();
+
+      expect(user.password).not.toBe(firstPassword);
+      expect(user.password).not.toBe('NewPassword123');
+    });
+  });
+
+  describe('User JSON Transformation', () => {
+    it('should exclude password and __v from JSON output', async () => {
+      const user = new User(mockUserData);
+      await user.save();
+
+      const json = user.toJSON();
+
+      expect(json.password).toBeUndefined();
+      expect(json.__v).toBeUndefined();
+      expect(json.email).toBeDefined();
+      expect(json._id).toBeDefined();
+    });
+  });
+
+  describe('User Queries', () => {
+    it('should not include password in queries by default', async () => {
+      await User.create(mockUserData);
+
+      const user = await User.findOne({ email: mockUserData.email });
+
+      expect(user.password).toBeUndefined();
+    });
+
+    it('should include password when explicitly selected', async () => {
+      await User.create(mockUserData);
+
+      const user = await User.findOne({ email: mockUserData.email }).select(
+        '+password'
+      );
+
+      expect(user.password).toBeDefined();
+      expect(user.password).not.toBe(mockUserData.password); // Should be hashed
+    });
+  });
+
+  describe('User Arrays', () => {
+    it('should handle empty preferences array', async () => {
+      const user = new User({ ...mockUserData, preferences: [] });
+      const savedUser = await user.save();
+
+      expect(savedUser.preferences).toEqual([]);
+    });
+
+    it('should handle empty allergies array', async () => {
+      const user = new User({ ...mockUserData, allergies: [] });
+      const savedUser = await user.save();
+
+      expect(savedUser.allergies).toEqual([]);
+    });
+
+    it('should store multiple preferences', async () => {
+      const preferences = ['vegan', 'gluten-free', 'organic', 'low-sodium'];
+      const user = new User({ ...mockUserData, preferences });
+      const savedUser = await user.save();
+
+      expect(savedUser.preferences).toEqual(preferences);
+    });
+
+    it('should store multiple allergies', async () => {
+      const allergies = ['nuts', 'dairy', 'shellfish'];
+      const user = new User({ ...mockUserData, allergies });
+      const savedUser = await user.save();
+
+      expect(savedUser.allergies).toEqual(allergies);
+    });
+  });
+
+  describe('User Updates', () => {
+    it('should update user fields correctly', async () => {
+      const user = new User(mockUserData);
+      await user.save();
+
+      user.name = 'Updated Name';
+      user.weight = 75;
+      user.goal = 'lose_weight';
+      await user.save();
+
+      const updatedUser = await User.findById(user._id);
+      expect(updatedUser.name).toBe('Updated Name');
+      expect(updatedUser.weight).toBe(75);
+      expect(updatedUser.goal).toBe('lose_weight');
+    });
+
+    it('should update timestamps on modification', async () => {
+      const user = new User(mockUserData);
+      await user.save();
+      const originalUpdatedAt = user.updatedAt;
+
+      // Wait a bit to ensure timestamp difference
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      user.name = 'Updated Name';
+      await user.save();
+
+      expect(user.updatedAt.getTime()).toBeGreaterThan(
+        originalUpdatedAt.getTime()
+      );
+    });
+  });
+
+  describe('User Deletion', () => {
+    it('should delete user successfully', async () => {
+      const user = new User(mockUserData);
+      await user.save();
+
+      await User.findByIdAndDelete(user._id);
+
+      const deletedUser = await User.findById(user._id);
+      expect(deletedUser).toBeNull();
+    });
+  });
+});

--- a/src/test/unit/route/profileRoute.test.js
+++ b/src/test/unit/route/profileRoute.test.js
@@ -1,0 +1,119 @@
+const request = require('supertest');
+const express = require('express');
+const profileRoute = require('../../../route/profileRoute');
+const profileController = require('../../../controller/profileController');
+const { authenticate } = require('../../../middleware/authMiddleware');
+const { handleValidationErrors } = require('../../../middleware/validator');
+const { mockUpdateData } = require('../../helpers/mockData');
+
+// Mock dependencies
+jest.mock('../../../controller/profileController');
+jest.mock('../../../middleware/authMiddleware');
+jest.mock('../../../middleware/validator');
+
+// Create test app
+const app = express();
+app.use(express.json());
+app.use('/api/v1/profile', profileRoute);
+
+describe('Profile Routes Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock middleware to pass through
+    authenticate.mockImplementation((req, res, next) => {
+      req.user = { _id: 'mock-user-id' };
+      next();
+    });
+    handleValidationErrors.mockImplementation((req, res, next) => next());
+
+    // Default mock implementations
+    profileController.updateProfile.mockImplementation((req, res) => {
+      res.status(200).json({ success: true, message: 'Profile updated' });
+    });
+    profileController.getUserById.mockImplementation((req, res) => {
+      res.status(200).json({ success: true, data: { user: {} } });
+    });
+  });
+
+  describe('GET /api/v1/profile', () => {
+    it('should get current user profile', async () => {
+      const response = await request(app)
+        .get('/api/v1/profile')
+        .set('Authorization', 'Bearer mock-token')
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(authenticate).toHaveBeenCalled();
+      expect(profileController.getUserById).toHaveBeenCalled();
+    });
+
+    it('should require authentication', async () => {
+      await request(app).get('/api/v1/profile').expect(200);
+
+      expect(authenticate).toHaveBeenCalled();
+    });
+  });
+
+  describe('PATCH /api/v1/profile', () => {
+    it('should update user profile', async () => {
+      const response = await request(app)
+        .patch('/api/v1/profile')
+        .set('Authorization', 'Bearer mock-token')
+        .send(mockUpdateData)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(authenticate).toHaveBeenCalled();
+      expect(profileController.updateProfile).toHaveBeenCalled();
+    });
+
+    it('should call validation middleware', async () => {
+      await request(app)
+        .patch('/api/v1/profile')
+        .set('Authorization', 'Bearer mock-token')
+        .send(mockUpdateData)
+        .expect(200);
+
+      expect(handleValidationErrors).toHaveBeenCalled();
+    });
+
+    it('should require authentication', async () => {
+      await request(app)
+        .patch('/api/v1/profile')
+        .send(mockUpdateData)
+        .expect(200);
+
+      expect(authenticate).toHaveBeenCalled();
+    });
+
+    it('should handle partial updates', async () => {
+      const partialUpdate = { name: 'New Name' };
+
+      const response = await request(app)
+        .patch('/api/v1/profile')
+        .set('Authorization', 'Bearer mock-token')
+        .send(partialUpdate)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(profileController.updateProfile).toHaveBeenCalled();
+    });
+  });
+
+  describe('Route Not Found', () => {
+    it('should return 404 for non-existent routes', async () => {
+      await request(app)
+        .get('/api/v1/profile/nonexistent')
+        .set('Authorization', 'Bearer mock-token')
+        .expect(404);
+    });
+
+    it('should return 404 for invalid methods', async () => {
+      await request(app)
+        .delete('/api/v1/profile')
+        .set('Authorization', 'Bearer mock-token')
+        .expect(404);
+    });
+  });
+});

--- a/src/util/response.js
+++ b/src/util/response.js
@@ -2,10 +2,10 @@ exports.success = (res, data, message, status = 200, meta) => {
   const payload = {
     success: true,
     message,
-    // data
+    data: data || null
   };
 
-  if (data) payload.data = data;
+  // if (data) payload.data = data;
   if (meta) payload.meta = meta;
 
   return res.status(status).json(payload);


### PR DESCRIPTION
refactor: comment out home route for API

refactor: remove console log from userService

test: add mock data for user tests

test: setup in-memory MongoDB for tests

test: implement auth middleware tests

test: add validator middleware tests

test: create user model tests

test: implement profile route tests

fix: update response utility to handle data correctly